### PR TITLE
Fix cache clearing

### DIFF
--- a/src/__tests__/cache.test.ts
+++ b/src/__tests__/cache.test.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
-import { getCached, setCached } from '../cache';
+import { getCached, setCached, clearCache } from '../cache';
 import { getDigiPin } from '../core';
 
 describe('Cache Functions', () => {
   beforeEach(() => {
-    // Clear cache before each test
-    // Note: In a real implementation, you might want to add a clear() method to the cache
+    clearCache();
   });
 
   it('should cache and retrieve values', () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -10,6 +10,10 @@ export function setCached(lat: number, lng: number, pin: string): void {
   cache.set(`${lat},${lng}`, pin);
 }
 
+export function clearCache(): void {
+  cache.clear();
+}
+
 // src/reverseGeocode.ts
 import { getLatLngFromDigiPin } from './core';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@ export { batchEncode, batchDecode } from './batch';
 export { getDigiPin as encode, getLatLngFromDigiPin as decode } from './core';
 export { digiPinMiddleware } from './middleware';
 export { generateGrid } from './offlineGrid';
-export { getCached, setCached } from './cache';
+export { getCached, setCached, clearCache } from './cache';
 export { reverseGeocode } from './cache';


### PR DESCRIPTION
## Summary
- add `clearCache()` helper
- export `clearCache` and use it in cache tests

## Testing
- `npm test` *(fails: mocha not found)*
- `npx tsc` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_b_6852bb019acc832b9a499d7fde7eccdf