### PR TITLE
Release version 1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.3] - 2025-06-18
+
+### Changed
+- Bumped package version to 1.1.3
+
 ## [1.1.0] - 2024-12-19
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,15 @@
 {
   "name": "digipinjs",
-  "version": "1.0.0",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digipinjs",
-      "version": "1.0.0",
+      "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "bottleneck": "^2.19.5",
         "chalk": "^4.1.2",
-        "digipinjs": "^1.0.0",
         "express": "^4.18.2",
         "lru-cache": "^7.18.3",
         "yargs": "^17.6.2"
@@ -1709,24 +1707,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/digipinjs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/digipinjs/-/digipinjs-1.0.0.tgz",
-      "integrity": "sha512-HjloaJVzs3ZI7AtJaeY1Z5buRVYg13q40vArrqiMz+p2FDHAcnhmTp9GFunj25CZ9yWLaniZKo/ewGExhSAqOQ==",
-      "dependencies": {
-        "bottleneck": "^2.19.5",
-        "chalk": "^4.1.2",
-        "express": "^4.18.2",
-        "lru-cache": "^7.18.3",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "digipin-cli": "dist/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/doctrine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digipinjs",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A comprehensive TypeScript library for encoding and decoding Indian geographic coordinates into DIGIPIN format (Indian Postal Digital PIN system). Features CLI tools, caching, batch processing, and Express middleware for seamless integration.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- bump version to 1.1.3
- remove old self-dependency from lockfile
- update CHANGELOG for new release

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_6852bd519ebc832b9a1a9c29d4d8005c