### PR TITLE
Release geocode utilities 1.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.8] - 2025-06-24
+### Added
+- Reverse geocoding example demonstrating geo utilities
+- Mention Amogh Chavan in contributors
+- Document geocoding helpers in README
+### Changed
+- Bumped package version to 1.1.8
+
 ## [1.1.3] - 2025-06-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ const pin = getDigiPin(28.6139, 77.2090); // Delhi coordinates
 - 🌐 **Express Middleware**: Easy integration with web applications
 - 📊 **Grid Generation**: Create offline coordinate grids
 - 🔄 **Reverse Geocoding**: Convert DIGIPIN back to coordinates
+- 📐 **Geospatial Utilities**: Distance and nearest-point helpers
 - 📝 **TypeScript Support**: Full type definitions included
 
 ## 📦 Installation
@@ -188,6 +189,34 @@ app.use(digiPinMiddleware()); // Automatically adds X-DIGIPIN header
 generateGrid(20, 70, 30, 80, 0.1, 'grid.json');
 ```
 
+#### Reverse Geocoding
+```typescript
+import { reverseGeocode } from 'digipinjs';
+
+const location = reverseGeocode('39J-438-TJC7');
+console.log(location); // { latitude: 28.6139, longitude: 77.2090 }
+```
+
+#### Geo Utilities
+```typescript
+import {
+  getDistance,
+  getPreciseDistance,
+  orderByDistance,
+  findNearest
+} from 'digipinjs';
+
+const delhi = '39J-438-TJC7';
+const mumbai = '4FK-595-8823';
+
+console.log(getDistance(delhi, mumbai));        // distance in meters
+console.log(getPreciseDistance(delhi, mumbai)); // precise distance
+
+const pins = [mumbai, '2L7-3K9-8P2F']; // Mumbai, Bangalore
+console.log(orderByDistance(delhi, pins)); // sorted by proximity
+console.log(findNearest(delhi, pins));    // nearest pin
+```
+
 ### 3. Common Use Cases
 
 #### E-commerce & Delivery
@@ -274,6 +303,8 @@ npm run lint
 
 # Run the example
 node examples/full-usage-npm.js
+# Geocoding & geo utilities example
+node examples/geocode-example.js
 ```
 
 ## 📊 Performance
@@ -293,6 +324,15 @@ npm install
 npm run build
 npm test
 ```
+
+## 👥 Contributors
+
+We'd like to thank the following contributors:
+
+- Department of Posts, Government of India
+- Indian Institute of Technology, Hyderabad
+- National Remote Sensing Centre, ISRO
+- [Amogh Chavan](https://github.com/amoghchavan)
 
 ## 📄 License
 

--- a/examples/geocode-example.js
+++ b/examples/geocode-example.js
@@ -1,0 +1,22 @@
+// examples/geocode-example.js
+
+const {
+  reverseGeocode,
+  getDistance,
+  getPreciseDistance,
+  orderByDistance,
+  findNearest,
+} = require('digipinjs');
+
+const delhi = '39J-438-TJC7';
+const mumbai = '4FK-595-8823';
+
+const location = reverseGeocode(delhi);
+console.log(`DigiPIN ${delhi} ->`, location);
+
+console.log('Distance Delhi-Mumbai:', getDistance(delhi, mumbai));
+console.log('Precise distance:', getPreciseDistance(delhi, mumbai));
+
+const pins = [mumbai, '2L7-3K9-8P2F']; // Mumbai, Bangalore
+console.log('Sorted pins:', orderByDistance(delhi, pins));
+console.log('Nearest pin:', findNearest(delhi, pins));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "digipinjs",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "digipinjs",
-      "version": "1.1.7",
+      "version": "1.1.8",
       "license": "MIT",
       "dependencies": {
         "geolib": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digipinjs",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A comprehensive TypeScript library for encoding and decoding Indian geographic coordinates into DIGIPIN format (Indian Postal Digital PIN system). Features CLI tools, caching, batch processing, and Express middleware for seamless integration.",
   "main": "dist/index.js",
   "browser": "dist/index.js",
@@ -75,6 +75,10 @@
     {
       "name": "National Remote Sensing Centre, ISRO",
       "url": "https://www.nrsc.gov.in/"
+    },
+    {
+      "name": "Amogh Chavan",
+      "url": "https://github.com/amoghchavan"
     }
   ],
   "license": "MIT",


### PR DESCRIPTION
## Summary
- update changelog with geocode helper notes
- bump version to 1.1.8 and credit Amogh Chavan
- document reverse geocoding and utility example usage
- add a Contributors section in the README listing Amogh Chavan

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ac62a8650832b829ebb90666a031d